### PR TITLE
Fix for the day bug

### DIFF
--- a/Sensair.ino
+++ b/Sensair.ino
@@ -175,6 +175,7 @@ void loop() {
 
     if ( loopTime > currentTime ) {
       currentTime = loopTime;
+      ROMVar::setCurrentTime(currentTime);
 
       float voMeasured = 0;
       float calcVoltage = 0;
@@ -206,10 +207,10 @@ void loop() {
       fileProcessor.openAppropiateFile(prevMinuteTime);
       fileProcessor.storeAverageData(prevMinuteTime, stateManager.microclimate);
       nextMinuteTime = calculateNextMinute();
+      ROMVar::setNextMinuteTime(nextMinuteTime);
+      
     }
 
-    ROMVar::setCurrentTime(currentTime);
-    ROMVar::setNextMinuteTime(nextMinuteTime);
   }
 
   // Send packets if there's something requesting it

--- a/classes/EEPROMVariables.h
+++ b/classes/EEPROMVariables.h
@@ -10,17 +10,19 @@
 
 // Required (stores first reading so device knows where to look for code)
 #define FIRST_READING     0   // long (4 bytes)
+#define LATEST_READING    4   // long (4 bytes)
+
 // Volatile (does not need to be saved)
-#define CURRENT_TIME      4   // long (4 bytes)
-#define NEXT_MINUTE_TIME  8   // long (4 bytes)
-#define READING_TOTAL     12  // float (4 bytes)
-#define LAT_TOTAL         16  // float (4 bytes)
-#define LON_TOTAL         20  // float (4 bytes)
-#define ELE_TOTAL         24  // float (4 bytes)
-#define LAT_MAX           28  // float (4 bytes)
-#define LAT_MIN           32  // float (4 bytes)
-#define LON_MAX           36  // float (4 bytes)
-#define LON_MIN           40  // float (4 bytes)
+#define CURRENT_TIME      12  // long (4 bytes)
+#define NEXT_MINUTE_TIME  16  // long (4 bytes)
+#define READING_TOTAL     20  // float (4 bytes)
+#define LAT_TOTAL         24  // float (4 bytes)
+#define LON_TOTAL         28  // float (4 bytes)
+#define ELE_TOTAL         32  // float (4 bytes)
+#define LAT_MAX           36  // float (4 bytes)
+#define LAT_MIN           40  // float (4 bytes)
+#define LON_MAX           44  // float (4 bytes)
+#define LON_MIN           48  // float (4 bytes)
 
 class ROMVar {
 private:
@@ -70,7 +72,15 @@ public:
   static long getFirstReading() {
     return getLong(FIRST_READING);
   }
-  
+
+  static void setLatestReading(long time) {
+    setLong(LATEST_READING, time);
+  }
+
+  static long getLatestReading() {
+    return getLong(LATEST_READING);
+  }
+
   static void setCurrentTime(long time) {
     setLong(CURRENT_TIME, time);
   }

--- a/classes/FileProcessor.h
+++ b/classes/FileProcessor.h
@@ -144,9 +144,7 @@ public:
     ROMVar::setAverageVars(zero,zero,zero,zero);
     readingCount = 0;
 
-    if ( firstReading == 0 ) {
-      setFirstReading(firstReading);
-    }
+
 
     if ( currentDayFile ) {
       DateTime now(minuteTime);
@@ -173,6 +171,10 @@ public:
       currentDayFile.print(accuracy,2);
       currentDayFile.write("\n");
       currentDayFile.close();
+      if ( firstReading == 0 ) {
+        setFirstReading(minuteTime);
+      }
+      ROMVar::setLatestReading(minuteTime);
     }
   }
 

--- a/classes/FileProcessor.h
+++ b/classes/FileProcessor.h
@@ -368,7 +368,7 @@ public:
         readingIterator = 0;
       }
       if ( lines == 0 ) {
-        Serial.print("EOF");
+        Serial.println("EOF");
         readingIterator = FileProcessor::getStartOfDay(readingIterator) + SECONDS_IN_DAY;
         // -Serial.println(readingIterator);
       }


### PR DESCRIPTION
The file scanning logic had a bug where it would stop once it no longer detects a day file. This meant that if the sensor is missing a day of readings, it will stop there.

It now stores the latest reading timestamp and scans until it reaches that latest reading, skipping over files that are empty.

Also another unrelated bug where it saved each reading twice per minute, screwing up a lot of shit.